### PR TITLE
Change Host() to get IP from end of the range when negative number given

### DIFF
--- a/cidr/cidr.go
+++ b/cidr/cidr.go
@@ -61,7 +61,14 @@ func Host(base *net.IPNet, num int) (net.IP, error) {
 	hostLen := addrLen - parentLen
 
 	maxHostNum := uint64(1<<uint64(hostLen)) - 1
-	if uint64(num) > maxHostNum {
+
+	numUint64 := uint64(num)
+	if num < 0 {
+		numUint64 = uint64(-num) - 1
+		num = int(maxHostNum - numUint64)
+	}
+
+	if numUint64 > maxHostNum {
 		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
 	}
 

--- a/cidr/cidr_test.go
+++ b/cidr/cidr_test.go
@@ -117,6 +117,21 @@ func TestHost(t *testing.T) {
 			Num:   256,
 			Error: true, // only 0-255 will fit in 8 bits
 		},
+		Case{
+			Range:  "192.168.0.0/30",
+			Num:    -3,
+			Output: "192.168.0.1", // 4 address (0-3) in 2 bits; 3rd from end = 1
+		},
+		Case{
+			Range:  "192.168.0.0/30",
+			Num:    -4,
+			Output: "192.168.0.0", // 4 address (0-3) in 2 bits; 4th from end = 0
+		},
+		Case{
+			Range:  "192.168.0.0/30",
+			Num:    -5,
+			Error:  true, // 4 address (0-3) in 2 bits; cannot accomodate 5
+		},
 	}
 
 	for _, testCase := range cases {


### PR DESCRIPTION
Per title; I would like to use this in Terraform.

The expected behavior, which is also demonstrated in the test code, is as follows:
Given CIDR range and a negative number, get IP address from the end of the range.

Say the CIDR range is `168.192.0.0/24`.
`-1` will gives you `168.192.0.255` (the last address), or `-256` will `168.192.0.0`. In this sense, giving `-257` will be an error because it's out of the range.

| num | num from end | IP            |
|----:|-------------:|:--------------|
|   0 |          256 | 168.192.0.0   |
|   1 |          255 | 168.192.0.1   |
| ... |          ... | ...           |
| 254 |            2 | 168.192.0.254 |
| 255 |            1 | 168.192.0.255 |
