### PR TITLE
broken test case: VerifyNoOverlap does not detect root block as overlapping other nets

### DIFF
--- a/cidr/cidr_test.go
+++ b/cidr/cidr_test.go
@@ -400,9 +400,10 @@ func TestVerifyNetowrk(t *testing.T) {
 		&testVerifyNetwork{
 			CIDRBlock: "10.42.0.0/24",
 			CIDRList: []string{
-				"10.42.0.0/24",
+
 				"10.42.0.16/28",
 				"10.42.0.32/28",
+				"10.42.0.0/24",
 			},
 		},
 	}

--- a/cidr/cidr_test.go
+++ b/cidr/cidr_test.go
@@ -397,6 +397,14 @@ func TestVerifyNetowrk(t *testing.T) {
 				"192.168.12.128/26",
 			},
 		},
+		&testVerifyNetwork{
+			CIDRBlock: "10.42.0.0/24",
+			CIDRList: []string{
+				"10.42.0.0/24",
+				"10.42.0.16/28",
+				"10.42.0.32/28",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This test breaks `VerifyNoOverlap`.

If you attempt to check the superblock itself as one of the networks given in the array, no overlap is detected. 

Our use case is stepping through a block with existing allocations and returning the allocated and unallocated space in the smallest bits possible, in order. It starts off a loop with the superblock network address , stepping down the mask size (beginning at the superblock size) until it either matches an allocation or detects enough empty space, then moving the address by one subnet of the size of the block just written.

This includes attempting to return the entire space as unallocated if no existing allocations are given.