### PR TITLE
Avoid int32 overflow in cidr.Host()

### DIFF
--- a/cidr/cidr.go
+++ b/cidr/cidr.go
@@ -44,7 +44,7 @@ func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
 	}
 
 	return &net.IPNet{
-		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		IP:   insertNumIntoIP(ip, big.NewInt(int64(num)), newPrefixLen),
 		Mask: net.CIDRMask(newPrefixLen, addrLen),
 	}, nil
 }
@@ -56,19 +56,23 @@ func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
 func Host(base *net.IPNet, num int) (net.IP, error) {
 	ip := base.IP
 	mask := base.Mask
+	bigNum := big.NewInt(int64(num))
 
 	parentLen, addrLen := mask.Size()
 	hostLen := addrLen - parentLen
 
-	maxHostNum := uint64(1<<uint64(hostLen)) - 1
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
 
-	numUint64 := uint64(num)
-	if num < 0 {
-		numUint64 = uint64(-num) - 1
-		num = int(maxHostNum - numUint64)
+	numUint64 := big.NewInt(int64(bigNum.Uint64()))
+	if bigNum.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(bigNum)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		bigNum.Sub(maxHostNum, numUint64)
 	}
 
-	if numUint64 > maxHostNum {
+	if numUint64.Cmp(maxHostNum) == 1 {
 		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
 	}
 	var bitlength int
@@ -77,7 +81,7 @@ func Host(base *net.IPNet, num int) (net.IP, error) {
 	} else {
 		bitlength = 128
 	}
-	return insertNumIntoIP(ip, num, bitlength), nil
+	return insertNumIntoIP(ip, bigNum, bitlength), nil
 }
 
 // AddressRange returns the first and last addresses in the given CIDR range.

--- a/cidr/cidr_test.go
+++ b/cidr/cidr_test.go
@@ -139,6 +139,16 @@ func TestHost(t *testing.T) {
 			Num:   -5,
 			Error: true, // 4 address (0-3) in 2 bits; cannot accomodate 5
 		},
+		Case{
+			Range:  "fd9d:bc11:4020::/64",
+			Num:    2,
+			Output: "fd9d:bc11:4020::2",
+		},
+		Case{
+			Range:  "fd9d:bc11:4020::/64",
+			Num:    -2,
+			Output: "fd9d:bc11:4020:0:ffff:ffff:ffff:fffe",
+		},
 	}
 
 	for _, testCase := range cases {

--- a/cidr/wrangling.go
+++ b/cidr/wrangling.go
@@ -29,9 +29,8 @@ func intToIP(ipInt *big.Int, bits int) net.IP {
 	return net.IP(ret)
 }
 
-func insertNumIntoIP(ip net.IP, num int, prefixLen int) net.IP {
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
 	ipInt, totalBits := ipToInt(ip)
-	bigNum := big.NewInt(int64(num))
 	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
 	ipInt.Or(ipInt, bigNum)
 	return intToIP(ipInt, totalBits)


### PR DESCRIPTION
See https://github.com/hashicorp/terraform/issues/22352

`int(maxHostNum - numUint64)` may overflow from the range of int32 when passes IPv6 address.

In particular, passing a negative value such as `cidr.Host("fd9d:bc11:4020::/64 ", -2)` may return unexpected results.

This pull request uses the `math/big` package to avoid the issue.