### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project stays architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+  - ppc64le
+  - amd64
 go:
   - 1.x
   - 1.7.x


### PR DESCRIPTION
Please review and merge the changes ,This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.